### PR TITLE
Added Lenovo Yoga 2 13 configuration

### DIFF
--- a/Configs/Lenovo Yoga 2 13.xml
+++ b/Configs/Lenovo Yoga 2 13.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>20344</NotebookModel>
+  <Author>AndreyL</Author>
+  <EcPollInterval>3000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>75</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>171</ReadRegister>
+      <WriteRegister>171</WriteRegister>
+      <MinSpeedValue>0</MinSpeedValue>
+      <MaxSpeedValue>8</MaxSpeedValue>
+      <ResetRequired>true</ResetRequired>
+      <FanSpeedResetValue>8</FanSpeedResetValue>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>57</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>


### PR DESCRIPTION
This config fits to the Lenovo Yoga 2 13 model number 20344, sold in Germany by Amazon: 13,3 Zoll FHD IPS, Intel Core i5-4210U, 2,7GHz, 8GB RAM, 256GB SSD, Intel HD Graphics 4400.

P.S. Thanks for the great piece of software, this makes my life much better :+1: 
