### PR TITLE
Update Asus Zenbook UX302LA.xml

### DIFF
--- a/Configs/Asus Zenbook UX302LA.xml
+++ b/Configs/Asus Zenbook UX302LA.xml
@@ -11,6 +11,9 @@
       <WriteRegister>151</WriteRegister>
       <MinSpeedValue>0</MinSpeedValue>
       <MaxSpeedValue>8</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>0</MaxSpeedValueRead>
       <ResetRequired>true</ResetRequired>
       <FanSpeedResetValue>9</FanSpeedResetValue>
       <TemperatureThresholds>
@@ -20,23 +23,33 @@
           <FanSpeed>0</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
-          <UpThreshold>72</UpThreshold>
+          <UpThreshold>69</UpThreshold>
           <DownThreshold>67</DownThreshold>
-          <FanSpeed>22.5</FanSpeed>
+          <FanSpeed>12.5</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>71</UpThreshold>
+          <DownThreshold>69</DownThreshold>
+          <FanSpeed>25</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>73</UpThreshold>
+          <DownThreshold>71</DownThreshold>
+          <FanSpeed>37.5</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>75</UpThreshold>
-          <DownThreshold>70</DownThreshold>
-          <FanSpeed>40</FanSpeed>
+          <DownThreshold>73</DownThreshold>
+          <FanSpeed>50</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
-          <UpThreshold>78</UpThreshold>
-          <DownThreshold>74</DownThreshold>
-          <FanSpeed>65</FanSpeed>
+          <UpThreshold>77</UpThreshold>
+          <DownThreshold>75</DownThreshold>
+          <FanSpeed>75</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
-          <UpThreshold>81</UpThreshold>
-          <DownThreshold>77</DownThreshold>
+          <UpThreshold>79</UpThreshold>
+          <DownThreshold>76</DownThreshold>
           <FanSpeed>100</FanSpeed>
         </TemperatureThreshold>
       </TemperatureThresholds>


### PR DESCRIPTION


Modified the fan to start at 12% speed, instead of 22%, also including more intermediate points for temperature vs. fan speed.