### PR TITLE
Created config for Toshiba Satellite L745

### DIFF
--- a/Configs/Toshiba Satellite L740.xml
+++ b/Configs/Toshiba Satellite L740.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <NotebookModel>Toshiba Satellite L740 , Bios v2.60 , EC v2.50</NotebookModel>
+  <Author>msafwan</Author>
+  <EcPollInterval>3000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>75</CriticalTemperature>
+  <FanConfigurations>
+  <FanConfiguration>
+    <ReadRegister>197</ReadRegister>
+    <WriteRegister>94</WriteRegister>
+    <MinSpeedValue>1</MinSpeedValue>
+    <MaxSpeedValue>3</MaxSpeedValue>
+    <IndependentReadMinMaxValues>true</IndependentReadMinMaxValues>
+    <MinSpeedValueRead>0</MinSpeedValueRead>
+    <MaxSpeedValueRead>205</MaxSpeedValueRead>
+    <ResetRequired>true</ResetRequired>
+    <FanSpeedResetValue>2</FanSpeedResetValue>
+    <FanDisplayName>CPU Fan Level</FanDisplayName>
+    <TemperatureThresholds>
+      <TemperatureThreshold>
+        <UpThreshold>50</UpThreshold>
+        <DownThreshold>50</DownThreshold>
+        <FanSpeed>100</FanSpeed>
+      </TemperatureThreshold>
+      <TemperatureThreshold>
+        <UpThreshold>35</UpThreshold>
+        <DownThreshold>35</DownThreshold>
+        <FanSpeed>50</FanSpeed>
+      </TemperatureThreshold>
+      <TemperatureThreshold>
+        <UpThreshold>20</UpThreshold>
+        <DownThreshold>20</DownThreshold>
+        <FanSpeed>0</FanSpeed>
+      </TemperatureThreshold>
+    </TemperatureThresholds>
+    <FanSpeedPercentageOverrides />
+  </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>

--- a/Configs/Toshiba Satellite L745.xml
+++ b/Configs/Toshiba Satellite L745.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <FanControlConfigV2 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-	<NotebookModel>Toshiba Satellite L745/L740 , Bios v2.60 , EC v2.50</NotebookModel>
+	<NotebookModel>Toshiba Satellite L745 , Bios v2.60 , EC v2.50</NotebookModel>
 	<Author>msafwan</Author>
 	<EcPollInterval>3000</EcPollInterval>
 	<ReadWriteWords>false</ReadWriteWords>

--- a/Configs/Toshiba Satellite L745.xml
+++ b/Configs/Toshiba Satellite L745.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<NotebookModel>Toshiba Satellite L745/L740 , Bios v2.60 , EC v2.50</NotebookModel>
+	<Author>msafwan</Author>
+	<EcPollInterval>3000</EcPollInterval>
+	<ReadWriteWords>false</ReadWriteWords>
+	<CriticalTemperature>75</CriticalTemperature>
+	<FanConfigurations>
+		<FanConfiguration>
+			<ReadRegister>197</ReadRegister>
+			<WriteRegister>94</WriteRegister>
+			<MinSpeedValue>1</MinSpeedValue>
+			<MaxSpeedValue>3</MaxSpeedValue>
+			<IndependentReadMinMaxValues>true</IndependentReadMinMaxValues>
+			<MinSpeedValueRead>0</MinSpeedValueRead>
+			<MaxSpeedValueRead>205</MaxSpeedValueRead>
+			<ResetRequired>true</ResetRequired>
+			<FanSpeedResetValue>2</FanSpeedResetValue>
+			<FanDisplayName>CPU Fan Level</FanDisplayName>
+			<TemperatureThresholds>
+				<TemperatureThreshold>
+					<UpThreshold>50</UpThreshold>
+					<DownThreshold>50</DownThreshold>
+					<FanSpeed>100</FanSpeed>
+				</TemperatureThreshold>
+				<TemperatureThreshold>
+					<UpThreshold>35</UpThreshold>
+					<DownThreshold>35</DownThreshold>
+					<FanSpeed>50</FanSpeed>
+				</TemperatureThreshold>
+				<TemperatureThreshold>
+					<UpThreshold>20</UpThreshold>
+					<DownThreshold>20</DownThreshold>
+					<FanSpeed>0</FanSpeed>
+				</TemperatureThreshold>
+		</TemperatureThresholds>
+		<FanSpeedPercentageOverrides />
+		</FanConfiguration>
+	</FanConfigurations>
+	<RegisterWriteConfigurations />
+</FanControlConfigV2>


### PR DESCRIPTION
Hello, this is fan config for Toshiba Satellite L740 & L745. Both uses same motherboard and BIOS and its BIOS updates also updated the EC version, so I put all of this info into the "notebook model".

I can't find documentation for this laptop, but I only found 3 fan level; 100%, 75%, and 50% after I inspected the EC with RW. The fan speed varies gradually whenever I change the level, with 50% making zero noise.