### PR TITLE
add config for Asus Zenbook UX430UA

### DIFF
--- a/Configs/Asus Zenbook UX430UA.xml
+++ b/Configs/Asus Zenbook UX430UA.xml
@@ -38,18 +38,18 @@
           <FanSpeed>37.5</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
-          <UpThreshold>80</UpThreshold>
-          <DownThreshold>78</DownThreshold>
+          <UpThreshold>78</UpThreshold>
+          <DownThreshold>76</DownThreshold>
           <FanSpeed>50</FanSpeed>
-        </TemperatureThreshold>
-        <TemperatureThreshold>
-          <UpThreshold>90</UpThreshold>
-          <DownThreshold>87</DownThreshold>
-          <FanSpeed>100</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>85</UpThreshold>
           <DownThreshold>83</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>83</UpThreshold>
+          <DownThreshold>81</DownThreshold>
           <FanSpeed>75</FanSpeed>
         </TemperatureThreshold>
       </TemperatureThresholds>

--- a/Configs/Asus Zenbook UX430UA.xml
+++ b/Configs/Asus Zenbook UX430UA.xml
@@ -42,6 +42,16 @@
           <DownThreshold>78</DownThreshold>
           <FanSpeed>50</FanSpeed>
         </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>90</UpThreshold>
+          <DownThreshold>87</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>85</UpThreshold>
+          <DownThreshold>83</DownThreshold>
+          <FanSpeed>75</FanSpeed>
+        </TemperatureThreshold>
       </TemperatureThresholds>
       <FanSpeedPercentageOverrides />
     </FanConfiguration>

--- a/Configs/Asus Zenbook UX430UA.xml
+++ b/Configs/Asus Zenbook UX430UA.xml
@@ -24,7 +24,7 @@
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>62</UpThreshold>
-          <DownThreshold>60</DownThreshold>
+          <DownThreshold>52</DownThreshold>
           <FanSpeed>12.5</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>

--- a/Configs/Asus Zenbook UX430UA.xml
+++ b/Configs/Asus Zenbook UX430UA.xml
@@ -1,43 +1,46 @@
 <?xml version="1.0"?>
 <FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <NotebookModel>UX430UA</NotebookModel>
-  <EcPollInterval>150</EcPollInterval>
+  <NotebookModel>ASUSTeK COMPUTER INC. UX430UA</NotebookModel>
+  <Author>sladiri</Author>
+  <EcPollInterval>300</EcPollInterval>
   <ReadWriteWords>false</ReadWriteWords>
-  <CriticalTemperature>75</CriticalTemperature>
-  <Author>xant1, jws</Author>
+  <CriticalTemperature>85</CriticalTemperature>
   <FanConfigurations>
     <FanConfiguration>
       <ReadRegister>151</ReadRegister>
       <WriteRegister>151</WriteRegister>
       <MinSpeedValue>0</MinSpeedValue>
       <MaxSpeedValue>8</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>0</MaxSpeedValueRead>
       <ResetRequired>true</ResetRequired>
       <FanSpeedResetValue>9</FanSpeedResetValue>
       <TemperatureThresholds>
         <TemperatureThreshold>
-          <UpThreshold>50</UpThreshold>
+          <UpThreshold>0</UpThreshold>
           <DownThreshold>0</DownThreshold>
           <FanSpeed>0</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
-          <UpThreshold>65</UpThreshold>
-          <DownThreshold>50</DownThreshold>
-          <FanSpeed>28.571428571428569</FanSpeed>
+          <UpThreshold>62</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>12.5</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>70</UpThreshold>
-          <DownThreshold>60</DownThreshold>
-          <FanSpeed>57.142857142857139</FanSpeed>
+          <DownThreshold>66</DownThreshold>
+          <FanSpeed>25</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>74</UpThreshold>
+          <DownThreshold>72</DownThreshold>
+          <FanSpeed>37.5</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>80</UpThreshold>
-          <DownThreshold>70</DownThreshold>
-          <FanSpeed>85.714285714285708</FanSpeed>
-        </TemperatureThreshold>
-        <TemperatureThreshold>
-          <UpThreshold>85</UpThreshold>
-          <DownThreshold>75</DownThreshold>
-          <FanSpeed>100</FanSpeed>
+          <DownThreshold>78</DownThreshold>
+          <FanSpeed>50</FanSpeed>
         </TemperatureThreshold>
       </TemperatureThresholds>
       <FanSpeedPercentageOverrides />
@@ -51,6 +54,7 @@
       <Value>10</Value>
       <ResetRequired>true</ResetRequired>
       <ResetValue>10</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
     </RegisterWriteConfiguration>
     <RegisterWriteConfiguration>
       <WriteMode>Set</WriteMode>
@@ -59,6 +63,7 @@
       <Value>10</Value>
       <ResetRequired>true</ResetRequired>
       <ResetValue>10</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
     </RegisterWriteConfiguration>
   </RegisterWriteConfigurations>
 </FanControlConfigV2>


### PR DESCRIPTION
I created this config based on the Asus Zenbook UX430UQ config by erkexzcx. (I the UX430UA config in master and imported the UX430UQ one).

I wanted to create a silent semi-passive config, and I tested it with Intel's Extreme Tuning Utility and its 5 minute CPU stress test.

According to NBFC's speed reading it actually maps the stock fan curve pretty well, just that my config lowers the fan speed by 12.5% across the entire temperature range. In the stress test (while charging too) the default settles at about 77degC package temp and 50% fan speed. My config got up to 80degC and 35.7% speed. This config allows the laptop to be silent at 0% speed most of the time.

sensors from XTU while CPU stress test and charging
stock: https://ibb.co/c825tG
semi-passive: https://ibb.co/gELKLw