### PR TITLE
Config: HP Elitebook Folio 9470m_i5-3427U_bios-F66

### DIFF
--- a/Configs/HP EliteBook Folio 9470m_i5-3427u_bios-F.66.xml
+++ b/Configs/HP EliteBook Folio 9470m_i5-3427u_bios-F.66.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>HP EliteBook Folio 9470m_i5-3427u_bios-F66</NotebookModel>
+  <EcPollInterval>3000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>85</CriticalTemperature>
+  <Author>Stefan Hirschmann</Author>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>46</ReadRegister>
+      <WriteRegister>47</WriteRegister>
+      <MinSpeedValue>60</MinSpeedValue>
+      <MaxSpeedValue>37</MaxSpeedValue>
+      <ResetRequired>true</ResetRequired>
+      <FanSpeedResetValue>255</FanSpeedResetValue>
+      <FanDisplayName>CPU Fan</FanDisplayName>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>65</UpThreshold>
+          <DownThreshold>55</DownThreshold>
+          <FanSpeed>15</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>30</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>75</UpThreshold>
+          <DownThreshold>65</DownThreshold>
+          <FanSpeed>60</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>80</UpThreshold>
+          <DownThreshold>70</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides>
+        <FanSpeedPercentageOverride>
+          <FanSpeedPercentage>0</FanSpeedPercentage>
+          <FanSpeedValue>255</FanSpeedValue>
+        </FanSpeedPercentageOverride>
+      </FanSpeedPercentageOverrides>
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>34</Register>
+      <Value>1</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>1</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Select thermal zone</Description>
+    </RegisterWriteConfiguration>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>38</Register>
+      <Value>28</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>0</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Fake thermal zone temperature</Description>
+    </RegisterWriteConfiguration>
+  </RegisterWriteConfigurations>
+</FanControlConfigV2>


### PR DESCRIPTION
Based on HP Elitebook Folio 9470m.xml
For CPU i5_3427U with Bios version F66.
Triggers fan later; smoother upward ramp; steeper downward ramp.
Higher critical temperature, according to sensors output and to 80% threshold from maximum die temp (105ºC).
Higher minimum and maximum speed values, according to probing preformed by trial and error and by watching automatically set values under load, respectively (see notes 1 and 2 at the end).
Aims to postpone the fan trigger and to reduce the time it is running.
Used for more than 6 months without issues so far.

Note 1: there's a considerable range of values between the first value which triggers the fan until the first value which scales the speed up. This config sets the highest value for the minimum speed (it eliminates a possible bias in the ramp of values).

Note 2: the scale of speed values supports higher speeds than the maximum set by this config, but those probably apply to different CPU's (in ex.: with higher TDP) on the same machine. This config sets the maximum value normally set by the BIOS under load, which I confirmed to maintain a stable temperature under high load (in ex.: prime95).