### PR TITLE
decimal <> hex value fix

### DIFF
--- a/Configs/Lenovo ThinkPad 13.xml
+++ b/Configs/Lenovo ThinkPad 13.xml
@@ -15,7 +15,7 @@
       <MinSpeedValueRead>0</MinSpeedValueRead>
       <MaxSpeedValueRead>22</MaxSpeedValueRead>
       <ResetRequired>true</ResetRequired>
-      <FanSpeedResetValue>80</FanSpeedResetValue>
+      <FanSpeedResetValue>128</FanSpeedResetValue>
       <FanDisplayName>System Fan</FanDisplayName>
       <TemperatureThresholds>
         <TemperatureThreshold>


### PR DESCRIPTION
I see that my e580 seems to behave in the same way, and I think this is a bug:

Author of this config probably wanted to set 80 as hex not as decimal

on my device this is what happens on exit:
hex 80 = dec 128 => factory auto mode
hex 50 = dec 80   => full speed of fan

I think author of config should confirm this before merge