### PR TITLE
HP Laptop 14-cm0xxx config

### DIFF
--- a/Configs/HP Laptop 14-cm0xxx.xml
+++ b/Configs/HP Laptop 14-cm0xxx.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>HP Laptop 14-cm0xxx</NotebookModel>
+  <Author>Matias Hiltunen</Author>
+  <EcPollInterval>500</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>76</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>113</ReadRegister>
+      <WriteRegister>219</WriteRegister>
+      <MinSpeedValue>55</MinSpeedValue>
+      <MaxSpeedValue>75</MaxSpeedValue>
+      <IndependentReadMinMaxValues>true</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>5</MinSpeedValueRead>
+      <MaxSpeedValueRead>12</MaxSpeedValueRead>
+      <ResetRequired>false</ResetRequired>
+      <FanSpeedResetValue>255</FanSpeedResetValue>
+      <FanDisplayName>CPU fan</FanDisplayName>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>68</UpThreshold>
+          <DownThreshold>54</DownThreshold>
+          <FanSpeed>10</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>71</UpThreshold>
+          <DownThreshold>62</DownThreshold>
+          <FanSpeed>20</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>73</UpThreshold>
+          <DownThreshold>66</DownThreshold>
+          <FanSpeed>50</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>75</UpThreshold>
+          <DownThreshold>70</DownThreshold>
+          <FanSpeed>70</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>78</UpThreshold>
+          <DownThreshold>74</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides>
+        <FanSpeedPercentageOverride>
+          <FanSpeedPercentage>0</FanSpeedPercentage>
+          <FanSpeedValue>0</FanSpeedValue>
+          <TargetOperation>Write</TargetOperation>
+        </FanSpeedPercentageOverride>
+        <FanSpeedPercentageOverride>
+          <FanSpeedPercentage>100</FanSpeedPercentage>
+          <FanSpeedValue>75</FanSpeedValue>
+          <TargetOperation>Write</TargetOperation>
+        </FanSpeedPercentageOverride>
+      </FanSpeedPercentageOverrides>
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>

--- a/Configs/HP Laptop 14-cm0xxx.xml
+++ b/Configs/HP Laptop 14-cm0xxx.xml
@@ -2,7 +2,7 @@
 <FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NotebookModel>HP Laptop 14-cm0xxx</NotebookModel>
   <Author>Matias Hiltunen</Author>
-  <EcPollInterval>500</EcPollInterval>
+  <EcPollInterval>200</EcPollInterval>
   <ReadWriteWords>false</ReadWriteWords>
   <CriticalTemperature>76</CriticalTemperature>
   <FanConfigurations>

--- a/Configs/HP Laptop 14-cm0xxx.xml
+++ b/Configs/HP Laptop 14-cm0xxx.xml
@@ -4,7 +4,7 @@
   <Author>Matias Hiltunen</Author>
   <EcPollInterval>200</EcPollInterval>
   <ReadWriteWords>false</ReadWriteWords>
-  <CriticalTemperature>76</CriticalTemperature>
+  <CriticalTemperature>80</CriticalTemperature>
   <FanConfigurations>
     <FanConfiguration>
       <ReadRegister>113</ReadRegister>


### PR DESCRIPTION
Add new config. It's working but its not perfect. Config does not set fan speed directly, but instead overrides one of the many temperature values. Config tries to keep cooling passive in web surfing. Probably requires setting "fan always on" to disabled in bios.