### PR TITLE
Add option to repeatedly output status information

### DIFF
--- a/Core/NbfcCli/CommandLineOptions/StatusVerb.cs
+++ b/Core/NbfcCli/CommandLineOptions/StatusVerb.cs
@@ -32,5 +32,14 @@ namespace NbfcCli.CommandLineOptions
             Constraint = NumArgsConstraint.AtLeast,
             Description = "Show fan status")]
         public List<int> Fan { get; set; }
+
+        [NamedArgument(
+            'p',
+            "poll",
+            Constraint = NumArgsConstraint.Optional,
+            Action = ParseAction.Store,
+            Description = "Output selected status every <value> seconds (default: 1)",
+            Const = 1f)]
+        public float? Poll { get; set; }
     }
 }

--- a/Core/NbfcCli/Program.cs
+++ b/Core/NbfcCli/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.ServiceModel;
 using System.Text;
+using System.Threading;
 
 namespace NbfcCli
 {
@@ -65,6 +66,9 @@ namespace NbfcCli
 
         private static void PrintStatus(StatusVerb verb)
         {
+            // If we are polling, we return to here:
+            start:
+
             FanControlInfo info = GetFanControlInfo();
 
             if (info == null)
@@ -106,6 +110,11 @@ namespace NbfcCli
                         PrintFanStatus(status);
                     }
                 }
+            }
+
+            if (verb.Poll.HasValue){
+                Thread.Sleep((int)(verb.Poll.Value*1000));
+                goto start;
             }
         }
 


### PR DESCRIPTION
This patch introduces a `-p` option to the `status` verb of the cli tool that causes the status to be repeatedly output. The rate is configurable as an optional argument to the parameter (measured in seconds, supporting float values.)

The rationale behind this patch is that I like to have a display of the current (target) fan speed in my system bar, and the CPU overhead from repeated mono startup was a major contributor to load on an otherwise idle system. Keeping a copy of the cli tool running in the background avoids that. I use this as an i3blocks element by running `nbfc status -p 1 -f 0 | awk '/Target/ { printf("%3d\n", $5) }'` with `interval=persist`.

If this is merged, we should be sure to update the CLI examples page on the Wiki.