### PR TITLE
Add config for HP Laptop 17-by1xxx.xml

### DIFF
--- a/Configs/HP Laptop 17-by1xxx.xml
+++ b/Configs/HP Laptop 17-by1xxx.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!--
+This config was manually created by trial and error based on the "HP Laptop 14-cm0xxx.xml". It may be necessary to disable the BIOS option "System Configuration: Fan Always On" in order to make the fan turn off completely.
+-->
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>HP Laptop 17-by1xxx</NotebookModel>
+  <Author>Zwergesel</Author>
+  <EcPollInterval>300</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>80</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>113</ReadRegister>
+      <WriteRegister>219</WriteRegister>
+      <MinSpeedValue>45</MinSpeedValue>
+      <MaxSpeedValue>80</MaxSpeedValue>
+      <IndependentReadMinMaxValues>true</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>7</MinSpeedValueRead>
+      <MaxSpeedValueRead>17</MaxSpeedValueRead>
+      <ResetRequired>false</ResetRequired>
+      <FanSpeedResetValue>0</FanSpeedResetValue>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>55</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>11.4285717</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>63</UpThreshold>
+          <DownThreshold>52</DownThreshold>
+          <FanSpeed>31.4285717</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>50</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>73</UpThreshold>
+          <DownThreshold>65</DownThreshold>
+          <FanSpeed>74.28571</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>78</UpThreshold>
+          <DownThreshold>69</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides>
+        <FanSpeedPercentageOverride>
+          <FanSpeedPercentage>0</FanSpeedPercentage>
+          <FanSpeedValue>0</FanSpeedValue>
+          <TargetOperation>Read</TargetOperation>
+        </FanSpeedPercentageOverride>
+        <FanSpeedPercentageOverride>
+          <FanSpeedPercentage>0</FanSpeedPercentage>
+          <FanSpeedValue>30</FanSpeedValue>
+          <TargetOperation>Write</TargetOperation>
+        </FanSpeedPercentageOverride>
+      </FanSpeedPercentageOverrides>
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>


### PR DESCRIPTION
This config was manually created by trial and error based on the "HP Laptop 14-cm0xxx.xml" and tested on an HP 17-by1102ng.

**Note**: It may be necessary to disable the BIOS option "_System Configuration_" > "_Fan Always On_" in order to make the fan turn off completely.

Quick overview:
* Writing to register 0xDB controls the fan speed, but the scale does not seem to be exactly linear. Writing values above 90 may crash the PC. The range 45 to 80 mapped roughly to the 10% - 100% speed with a special value of 30 to turn off the fan entirely (although any value < 35 will do that as far as I could tell).
* Reading from register 0x71 returns the current fan speed as values between 8 and 17 if the fan is spinning, so configuring 7 to 17 maps the fan speed nicely between 10% and 100%. Once again a special value of 0 is used if the fan is off.

Without NBFC the fans will only stop spinning at roughly < 35°C and otherwise be pretty much constantly spinning at 10%-20% which is fairly annoying. This config sets the temperature for the fan starting to spin at 55°C and ramps it up until it reaches 100% at 78°C. The NBFC config from which this was copied allowed even higher temperatures before starting the fan, but I wanted to keep it somewhat conservative. Maximum temperature of the CPU is listed as 100°C. [(source)](http://www.cpu-world.com/CPUs/Core_i5/Intel-Core%20i5%20i5-8265U.html)