### PR TITLE
Cosmetic update for config of Gigabyte AERO 14KV8

### DIFF
--- a/Configs/Gigabyte AERO 14KV8.xml
+++ b/Configs/Gigabyte AERO 14KV8.xml
@@ -39,14 +39,14 @@
           <FanSpeed>60.2620049</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
-          <UpThreshold>90</UpThreshold>
-          <DownThreshold>80</DownThreshold>
-          <FanSpeed>100</FanSpeed>
-        </TemperatureThreshold>
-        <TemperatureThreshold>
           <UpThreshold>85</UpThreshold>
           <DownThreshold>77</DownThreshold>
           <FanSpeed>80.34934</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>90</UpThreshold>
+          <DownThreshold>80</DownThreshold>
+          <FanSpeed>100</FanSpeed>
         </TemperatureThreshold>
       </TemperatureThresholds>
       <FanSpeedPercentageOverrides />
@@ -130,7 +130,7 @@
     </RegisterWriteConfiguration>
     <RegisterWriteConfiguration>
       <WriteMode>Set</WriteMode>
-      <WriteOccasion>OnWriteFanSpeed</WriteOccasion>
+      <WriteOccasion>OnInitialization</WriteOccasion>
       <Register>13</Register>
       <Value>1</Value>
       <ResetRequired>true</ResetRequired>


### PR DESCRIPTION
Thank you for the quick merge and the kind words.

This is a small cosmetic update for the Gigabyte AERO 14KV8 configuration that you just pulled:
- one of the RegisterWriteConfigurations unnecessarily had the write mode set to "OnWriteFanSpeed" even though it is enough to set the respective register once in order to enable the required fan mode. This is now fixed by setting the write mode to "OnInitialization" so that the register is not written all the time without need for it. 
- for one of the fans the temperature ranges were not listed in ascending order. This is not actually a problem but ascending order is nicer to read so I fixed this as well :-)

Thanks again for your great work and sorry for not catching these things right away
Christian