### PR TITLE
Use curl instead of wget since the mono docker image does not have it.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 NUGET_URL="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
 function download-nuget {
-    wget $NUGET_URL
+    curl -O $NUGET_URL
 	
     # import Mozilla trusted root certificates into mono certificates store
     


### PR DESCRIPTION
I followed the steps in the wiki to build nbfc with docker, but I had to make this change to get it to work.