### PR TITLE
Create HP Laptop 17-ca1xxx.xml

### DIFF
--- a/Configs/HP Laptop 17-ca1xxx.xml
+++ b/Configs/HP Laptop 17-ca1xxx.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>HP Laptop 17-ca1xxx</NotebookModel>
+  <Author>Harald Rohan</Author>
+  <EcPollInterval>200</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>80</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>128</ReadRegister>
+      <WriteRegister>219</WriteRegister>
+      <MinSpeedValue>34</MinSpeedValue>
+      <MaxSpeedValue>80</MaxSpeedValue>
+      <IndependentReadMinMaxValues>true</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>7</MaxSpeedValueRead>
+      <ResetRequired>false</ResetRequired>
+      <FanSpeedResetValue>255</FanSpeedResetValue>
+      <FanDisplayName>CPU fan</FanDisplayName>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>55</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>60</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>20</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>65</UpThreshold>
+          <DownThreshold>55</DownThreshold>
+          <FanSpeed>40</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>60</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>75</UpThreshold>
+          <DownThreshold>65</DownThreshold>
+          <FanSpeed>80</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>80</UpThreshold>
+          <DownThreshold>70</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>

--- a/Configs/HP Laptop 17-ca1xxx.xml
+++ b/Configs/HP Laptop 17-ca1xxx.xml
@@ -4,7 +4,7 @@
   <Author>Harald Rohan</Author>
   <EcPollInterval>200</EcPollInterval>
   <ReadWriteWords>false</ReadWriteWords>
-  <CriticalTemperature>80</CriticalTemperature>
+  <CriticalTemperature>81</CriticalTemperature>
   <FanConfigurations>
     <FanConfiguration>
       <ReadRegister>128</ReadRegister>


### PR DESCRIPTION
This config has been created manually using the ec probing tool and tested on an HP 17-ca1211ng Jet Black (7KG31EA#ABD).
The configuration is based on the "HP Laptop 14-cm0xxx.xml" from  Matias Hiltunen and the description was partially taken from Zwergesel (HP 17-by1102ng) - thanks to both.

Remark: It had to disable the BIOS option "System Configuration" > "Fan Always On" in order to make the fan turn off completely.

The configuration uses the write register 219/0xDB in a range from 34 to 80 and the read register 113/0x71 in a range from 0 to 7 based on educated guessing, so there could be better ones.
The fan seems to have 8 levels (including 0) and the read register maps nicely. 
The write register mapping is a bit exponential towards the end. And having 55 distinct values mapping to 8 stages seems also a bit confusing, e.g. when using the scroll bar in the UI.

The temperature thresholds have been mapped for my convenience so that the fan starts somewhere at 55 degrees, therefore feel free to change as you like. The ranges go up 80 degrees with some overlap.
This is based on my experience that the AMD Ryzen 3 3200U hardly crossed 65 degrees, with or without fan, even when the spec allows up to 105 degrees. Which means there might be some additional guards build-in anyway.

And I have to say thanks for this fantastic tool. Without the fan never stopped and I was close to send the new notebook back to HP straight ahead.