### PR TITLE
Fix 'HP ProBook 650 G2' not reaching 0%

### DIFF
--- a/Configs/HP ProBook 650 G2.xml
+++ b/Configs/HP ProBook 650 G2.xml
@@ -37,8 +37,13 @@
       <FanSpeedPercentageOverrides>
         <FanSpeedPercentageOverride>
           <FanSpeedPercentage>0</FanSpeedPercentage>
-          <FanSpeedValue>255</FanSpeedValue>
+          <FanSpeedValue>254</FanSpeedValue>
           <TargetOperation>ReadWrite</TargetOperation>
+        </FanSpeedPercentageOverride>
+        <FanSpeedPercentageOverride>
+          <FanSpeedPercentage>0</FanSpeedPercentage>
+          <FanSpeedValue>255</FanSpeedValue>
+          <TargetOperation>Read</TargetOperation>
         </FanSpeedPercentageOverride>
       </FanSpeedPercentageOverrides>
     </FanConfiguration>


### PR DESCRIPTION
When simply mapping fan register value of 255 to 0%, the fan is not able
to reach 0% directly when starting at a rather high speed, running
constantly at around 25% instead.  This can be worked around manually by
first setting the speed to a value between 0% and 20%, then setting it
to 0%.

Mapping the fan register value of 254 to 0% fixes the issue permanently.
Mapping read value of 255 to 0% fixes the percentage indicator which
shows negative speed values otherwise.