### PR TITLE
Add a new plugin for `acpi_ec`

### DIFF
--- a/Core/Plugins/StagWare.Plugins.ECModuleLinux/ECModuleLinux.cs
+++ b/Core/Plugins/StagWare.Plugins.ECModuleLinux/ECModuleLinux.cs
@@ -1,0 +1,178 @@
+﻿using Mono.Unix;
+using Mono.Unix.Native;
+using StagWare.FanControl.Plugins;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System;
+
+namespace StagWare.Plugins.ECModuleLinux
+{
+    [Export(typeof(IEmbeddedController))]
+    [FanControlPluginMetadata(
+        "StagWare.Plugins.ECModuleLinux",
+        SupportedPlatforms.Unix,
+        SupportedCpuArchitectures.x86 | SupportedCpuArchitectures.x64,
+        FanControlPluginMetadataAttribute.DefaultPriority + 20)]
+    public class ECModuleLinux : IEmbeddedController
+    {
+        #region Constants
+
+        private const string ECDevPath = "/dev/ec";
+
+        #endregion
+
+        #region Private Fields
+
+        static readonly object syncRoot = new object();
+        bool disposed;
+        UnixStream stream;
+
+        #endregion
+
+        #region IEmbeddedController implementation
+
+        public bool IsInitialized { get; private set; }
+
+        public void Initialize()
+        {
+            if (!this.IsInitialized)
+            {
+                try
+                {
+                    Process modprobe = new Process();
+                    modprobe.StartInfo.FileName = "modprobe";
+                    modprobe.StartInfo.Arguments = "acpi_ec";
+                    modprobe.Start();
+                    modprobe.WaitForExit();
+
+                    IsInitialized = modprobe.ExitCode == 0 && File.Exists(ECDevPath);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public void WriteByte(byte register, byte value)
+        {
+            byte[] buffer = { value };
+            this.stream.WriteAtOffset(buffer, 0, buffer.Length, register);
+        }
+
+        public void WriteWord(byte register, ushort value)
+        {
+            // little endian
+            byte msb = (byte)(value >> 8);
+            byte lsb = (byte)value;
+
+            byte[] buffer = { lsb, msb };
+            this.stream.WriteAtOffset(buffer, 0, buffer.Length, register);
+        }
+
+        public byte ReadByte(byte register)
+        {
+            byte[] buffer = new byte[1];
+            this.stream.ReadAtOffset(buffer, 0, buffer.Length, register);
+
+            return buffer[0];
+        }
+
+        public ushort ReadWord(byte register)
+        {
+            // little endian
+            byte[] buffer = new byte[2];
+            this.stream.ReadAtOffset(buffer, 0, buffer.Length, register);
+
+            return (ushort)((buffer[1] << 8) | buffer[0]);
+        }
+
+        public bool AcquireLock(int timeout)
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(ECModuleLinux));
+            }
+
+            bool success = false;
+            bool syncRootLockTaken = false;
+
+            try
+            {
+                Monitor.TryEnter(syncRoot, timeout, ref syncRootLockTaken);
+
+                if (!syncRootLockTaken)
+                {
+                    return false;
+                }
+
+                if (this.stream == null)
+                {
+                    int fd = Syscall.open(ECDevPath, OpenFlags.O_RDWR | OpenFlags.O_EXCL);
+
+                    if (fd == -1)
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    this.stream = new UnixStream(fd);
+                }
+
+                success = this.stream != null;
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e.Message);
+            }
+            finally
+            {
+                if (syncRootLockTaken && !success)
+                {
+                    Monitor.Exit(syncRoot);
+                }
+            }
+
+            return success;
+        }
+
+        public void ReleaseLock()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(ECModuleLinux));
+            }
+
+            try
+            {
+                if (this.stream != null)
+                {
+                    this.stream.Dispose();
+                    this.stream = null;
+                }
+            }
+            finally
+            {
+                Monitor.Exit(syncRoot);
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (syncRoot)
+            {
+                if (this.stream != null)
+                {
+                    this.stream.Dispose();
+                    this.stream = null;
+                }
+
+                disposed = true;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Core/Plugins/StagWare.Plugins.ECModuleLinux/Properties/AssemblyInfo.cs
+++ b/Core/Plugins/StagWare.Plugins.ECModuleLinux/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+[assembly: AssemblyTitle("StagWare.Plugins.ECModuleLinux")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyProduct("StagWare.Plugins.ECModuleLinux")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/Core/Plugins/StagWare.Plugins.ECModuleLinux/StagWare.Plugins.ECModuleLinux.csproj
+++ b/Core/Plugins/StagWare.Plugins.ECModuleLinux/StagWare.Plugins.ECModuleLinux.csproj
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{BBA487E7-9EB4-4BCE-99DA-0C0E9DDA543F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>StagWare.Plugins.ECModuleLinux</RootNamespace>
+    <AssemblyName>StagWare.Plugins.ECModuleLinux</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseLinux|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugLinux|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ECModuleLinux.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\StagWare.FanControl\StagWare.FanControl.csproj">
+      <Project>{12084B38-C1A2-414C-80A7-B8D02D6F5B84}</Project>
+      <Name>StagWare.FanControl</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Mono.Posix" />
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/NoteBookFanControl.sln
+++ b/NoteBookFanControl.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28803.156
@@ -70,6 +70,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{C7CC8E
 		Common\CommonAssemblyInfo.cs = Common\CommonAssemblyInfo.cs
 		Common\CommonAssemblyVersion.cs = Common\CommonAssemblyVersion.cs
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StagWare.Plugins.ECModuleLinux", "Core\Plugins\StagWare.Plugins.ECModuleLinux\StagWare.Plugins.ECModuleLinux.csproj", "{BBA487E7-9EB4-4BCE-99DA-0C0E9DDA543F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This pull request follows the issue #800. 
It adds a new plugin for access to the EC, using the `acpi_ec` kernel module. This plugin is especially useful when the Secure Boot is enabled, since it introduce "kernel lockdown" (https://github.com/hirschmann/nbfc/issues/472#issuecomment-388073176).
The code is mostly taken from the `ec_sys` plugin, with some modifications to make it work with the module.