### PR TITLE
Create Asus TP301UJ config

### DIFF
--- a/Configs/Asus TP301UJ.xml
+++ b/Configs/Asus TP301UJ.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>Asus TP301UJ</NotebookModel>
+  <Author>Joao Bravo</Author>
+  <EcPollInterval>1500</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>80</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>151</ReadRegister>
+      <WriteRegister>151</WriteRegister>
+      <MinSpeedValue>0</MinSpeedValue>
+      <MaxSpeedValue>8</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>0</MaxSpeedValueRead>
+      <ResetRequired>true</ResetRequired>
+      <FanSpeedResetValue>9</FanSpeedResetValue>
+      <FanDisplayName>CPU Fan</FanDisplayName>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>55</UpThreshold>
+          <DownThreshold>45</DownThreshold>
+          <FanSpeed>12.5</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>65</UpThreshold>
+          <DownThreshold>52</DownThreshold>
+          <FanSpeed>50</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>62</DownThreshold>
+          <FanSpeed>75</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>75</UpThreshold>
+          <DownThreshold>67</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnWriteFanSpeed</WriteOccasion>
+      <Register>160</Register>
+      <Value>45</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>45</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+    </RegisterWriteConfiguration>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnWriteFanSpeed</WriteOccasion>
+      <Register>166</Register>
+      <Value>45</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>45</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+    </RegisterWriteConfiguration>
+  </RegisterWriteConfigurations>
+</FanControlConfigV2>

--- a/Configs/Asus TP301UJ.xml
+++ b/Configs/Asus TP301UJ.xml
@@ -2,7 +2,7 @@
 <FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NotebookModel>Asus TP301UJ</NotebookModel>
   <Author>Joao Bravo</Author>
-  <EcPollInterval>1500</EcPollInterval>
+  <EcPollInterval>300</EcPollInterval>
   <ReadWriteWords>false</ReadWriteWords>
   <CriticalTemperature>80</CriticalTemperature>
   <FanConfigurations>


### PR DESCRIPTION
ASUS VivoBook Flip TP301UJ settings.
Registers 160 and 166 are overwritten to set minimum temperature to CPU and GPU.
No laptop modifications required. Working on multiple such laptops.