### PR TITLE
Add config for HP Pavilion Gaming 15-ec0xxx(Ryzen 3550H + GTX 1650)

### DIFF
--- a/Configs/HP Pavilion Gaming Laptop 15-ec0xxx.xml
+++ b/Configs/HP Pavilion Gaming Laptop 15-ec0xxx.xml
@@ -31,7 +31,7 @@
         <TemperatureThreshold>
           <UpThreshold>70</UpThreshold>
           <DownThreshold>60</DownThreshold>
-          <FanSpeed>90.38461</FanSpeed>
+          <FanSpeed>100</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>60</UpThreshold>

--- a/Configs/HP Pavilion Gaming Laptop 15-ec0xxx.xml
+++ b/Configs/HP Pavilion Gaming Laptop 15-ec0xxx.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>HP Pavilion Gaming 15-ec0xxx</NotebookModel>
+  <Author>Tejaswi Vykuntam</Author>
+  <EcPollInterval>1000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>68</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>45</ReadRegister>
+      <WriteRegister>45</WriteRegister>
+      <MinSpeedValue>38</MinSpeedValue>
+      <MaxSpeedValue>90</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>20</MinSpeedValueRead>
+      <MaxSpeedValueRead>70</MaxSpeedValueRead>
+      <ResetRequired>false</ResetRequired>
+      <FanSpeedResetValue>0</FanSpeedResetValue>
+      <FanDisplayName>CPU Fan</FanDisplayName>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>45</UpThreshold>
+          <DownThreshold>38</DownThreshold>
+          <FanSpeed>25</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>55</UpThreshold>
+          <DownThreshold>41</DownThreshold>
+          <FanSpeed>50</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>90.38461</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>60</UpThreshold>
+          <DownThreshold>45</DownThreshold>
+          <FanSpeed>75</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>

--- a/Configs/HP Pavilion Gaming Laptop 15-ec0xxx.xml
+++ b/Configs/HP Pavilion Gaming Laptop 15-ec0xxx.xml
@@ -4,7 +4,7 @@
   <Author>Tejaswi Vykuntam</Author>
   <EcPollInterval>1000</EcPollInterval>
   <ReadWriteWords>false</ReadWriteWords>
-  <CriticalTemperature>68</CriticalTemperature>
+  <CriticalTemperature>75</CriticalTemperature>
   <FanConfigurations>
     <FanConfiguration>
       <ReadRegister>45</ReadRegister>


### PR DESCRIPTION
Previous pull requests failed due to missing "Fanspeed 100" and critical temp being lower than one of the up thresholds.