### PR TITLE
mostly silent fan for HP ProBook 4540s

### DIFF
--- a/Configs/HP ProBook 4540s_silent.xml
+++ b/Configs/HP ProBook 4540s_silent.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>HP ProBook 4540s</NotebookModel>
+  <EcPollInterval>3000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>90</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>46</ReadRegister>
+      <WriteRegister>47</WriteRegister>
+      <MinSpeedValue>205</MinSpeedValue>
+      <MaxSpeedValue>52</MaxSpeedValue>
+      <ResetRequired>true</ResetRequired>
+      <FanSpeedResetValue>255</FanSpeedResetValue>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+	<TemperatureThreshold>
+          <UpThreshold>50</UpThreshold>
+          <DownThreshold>40</DownThreshold>
+          <FanSpeed>20</FanSpeed>
+        </TemperatureThreshold>
+	<TemperatureThreshold>
+          <UpThreshold>55</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>40</FanSpeed>
+        </TemperatureThreshold>
+	<TemperatureThreshold>
+          <UpThreshold>60</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>70</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>85</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>75</UpThreshold>
+          <DownThreshold>65</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>34</Register>
+      <Value>1</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>1</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Select thermal zone</Description>
+    </RegisterWriteConfiguration>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>38</Register>
+      <Value>28</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>0</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Fake thermal zone temperature</Description>
+    </RegisterWriteConfiguration>
+  </RegisterWriteConfigurations>
+</FanControlConfigV2>


### PR DESCRIPTION
based on file "HP ProBook 4540s.xml"
changed min and max fan speed values - got from tests with "ec-probe.exe"
because of that, changed fan speed at some steps
added further speed step(s)
changed critical temp to 90 degrees, because intel mentioned a max temp for cpus available in that probook of 100-105 degrees
at all the notebook is now silent till 60 degrees. before it was noisy all the time