### PR TITLE
Add config for Lenovo Yoga 500-15IBD

### DIFF
--- a/Configs/Lenovo Yoga 500-15IBD.xml
+++ b/Configs/Lenovo Yoga 500-15IBD.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>Lenovo Yoga 500-15IBD</NotebookModel>
+  <Author>Martin Pavelek</Author>
+  <EcPollInterval>300</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <!-- T_junction for i7-5500U is 105 °C, leave some margin -->
+  <CriticalTemperature>90</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>149</ReadRegister>
+      <WriteRegister>148</WriteRegister>
+      <MinSpeedValue>255</MinSpeedValue>
+      <MaxSpeedValue>80</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>0</MaxSpeedValueRead>
+      <ResetRequired>true</ResetRequired>
+      <FanSpeedResetValue>80</FanSpeedResetValue>
+      <FanDisplayName>Fan</FanDisplayName>
+      <TemperatureThresholds>
+        <!-- The controller has trouble keeping a set value at some points,
+             it keeps oscillating around it with a period of a second or two.
+             This may or may not differ on each machine or based on other
+             factors, so you may need to tweak the speeds +- a few percent
+             to find sweet-spots that work for you. -->
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>60</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>5</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>36</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>80</UpThreshold>
+          <DownThreshold>70</DownThreshold>
+          <FanSpeed>64</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>85</UpThreshold>
+          <DownThreshold>80</DownThreshold>
+          <FanSpeed>80</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>90</UpThreshold>
+          <DownThreshold>85</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>147</Register>
+      <Value>20</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>4</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Enable manual control</Description>
+    </RegisterWriteConfiguration>
+  </RegisterWriteConfigurations>
+</FanControlConfigV2>

--- a/Configs/Lenovo Yoga 500-15IBD.xml
+++ b/Configs/Lenovo Yoga 500-15IBD.xml
@@ -5,7 +5,7 @@
   <EcPollInterval>300</EcPollInterval>
   <ReadWriteWords>false</ReadWriteWords>
   <!-- T_junction for i7-5500U is 105 °C, leave some margin -->
-  <CriticalTemperature>90</CriticalTemperature>
+  <CriticalTemperature>95</CriticalTemperature>
   <FanConfigurations>
     <FanConfiguration>
       <ReadRegister>149</ReadRegister>


### PR DESCRIPTION
Hi,

Looking at the list of PRs I'm not sure if this issue tracker is dead or not, but in case anyone needs it, here is a config for Lenovo Yoga 500-15IBD (80N6).

It is very different from the existing config of similarly named Yoga 510, but it uses the same registers 147 / 148 / 149 (enable / write / read) as many other Lenovo models (Ideapad U160 and 500S-14ISK, Thinkpad L530 and L380 Yoga, V580 or U41-70). The main difference from these is `MaxSpeedValue` (reacts down to 0x80) and speeds / thresholds (changed + tweaked for my machine as described below).

**Notes for users**
There seems to be an issue with the controller: the PID or whatever regulator inside does a pretty poor job of keeping RPM at the set value. Instead, it can start to oscillate approximately +-5 % RPM around the set value, with period around one or two seconds. This can be quite annoying and is the reason why I looked into manual fan control in the first place.

It only happens at certain values and situations. For example, setting speed to 8 % may result in stable ~13 % RPM when ramping up from 0, but may start to oscillate between 0 and 14 % when ramping down from high RPM. Similarly, setting 36 % RPM results in stable 40 % RPM, but setting 38 % results in oscillation (33 % to 42 %). Lower speeds seem to be more prone to these problems.

I assume the behavior may be slightly different on other machines (e.g. dirty old fan may be harder to spin than a new one, so it may not overshoot the target as easily), so you may need to tweak the speeds +- a few percent to get the best, stable result on your machine.

---
**Note about performance**
This laptop has **bad** thermal design. With many loads it will throttle down to ~500 MHz even when the fan is set to constantly run at maximum speed. This configuration can't solve that, but it may improve the performance for some loads, since it can go to 100 % RPM when temperature rises over 90 °C (the default automatic mode only ever goes up to around 80 %).

~~If you want to get better sustained performance from this laptop, you have to limit the frequency to 2.3 GHz by:~~
EDIT: I found a better approach, see the post below.
```sudo sh -c "echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo"```
Unfortunately, tweaking max_perf_pct does not help, as value 76 equals 2.3 GHz, and values ranging from 77 to 100 enable all the turbo P-states at once, right up to the original 3.0 GHz maximum. Keeping the turbo mode enabled is only better for bursts up to 10 seconds. If you decide to disable turbo mode to get better sustained performance, you can also consider increasing `EcPollInterval` in this config from 300 to a higher value (e.g. 1500) since there is no need to react quickly to big temperature spikes.