### PR TITLE
Add config for HP Elitebook 850 G5

### DIFF
--- a/HP EliteBook 850 G5.xml
+++ b/HP EliteBook 850 G5.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+
+<!--
+    This config was manually created based on "HP EliteBook*.xml" configs (HP EliteBook 8760w.xml, 
+    HP EliteBook 840 G2.xml, etc.) and some others. MaxSpeedValue/MinSpeedValue were detected/checked 
+    with ec-probe tool. The config was created for HP EliteBook 850 G5 with Intel i5-8250U CPU and 
+    BIOS Q78 Ver. 01.16.00. And it was tested only on Linux.
+    It may be necessary to change/adjust temperature threshoulds for different CPU or/and personal 
+    preferences.  
+-->
+
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  
+  <NotebookModel>HP EliteBook 850 G5</NotebookModel>
+  <EcPollInterval>2000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>78</CriticalTemperature>
+  <Author>pustotnik</Author>
+  
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>46</ReadRegister>
+      <WriteRegister>47</WriteRegister>
+      <MinSpeedValue>255</MinSpeedValue>
+      <MaxSpeedValue>40</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>0</MaxSpeedValueRead>
+      <ResetRequired>true</ResetRequired>
+      <FanSpeedResetValue>255</FanSpeedResetValue>
+      <FanDisplayName>CPU fan</FanDisplayName>
+      
+      <TemperatureThresholds>
+        
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <!--<FanSpeed>19</FanSpeed> -->
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        
+        <TemperatureThreshold>
+          <UpThreshold>50</UpThreshold>
+          <DownThreshold>45</DownThreshold>
+          <FanSpeed>30</FanSpeed>
+        </TemperatureThreshold>
+        
+        <TemperatureThreshold>
+          <UpThreshold>55</UpThreshold>
+          <DownThreshold>48</DownThreshold>
+          <FanSpeed>60</FanSpeed>
+        </TemperatureThreshold>
+        
+        <TemperatureThreshold>
+          <UpThreshold>60</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>70</FanSpeed>
+        </TemperatureThreshold>
+        
+        <TemperatureThreshold>
+          <UpThreshold>63</UpThreshold>
+          <DownThreshold>56</DownThreshold>
+          <FanSpeed>78</FanSpeed>
+        </TemperatureThreshold>
+        
+        <TemperatureThreshold>
+          <UpThreshold>65</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>88</FanSpeed>
+        </TemperatureThreshold>
+        
+        <TemperatureThreshold>
+          <UpThreshold>68</UpThreshold>
+          <DownThreshold>62</DownThreshold>
+          <FanSpeed>90</FanSpeed>
+        </TemperatureThreshold>
+        
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>66</DownThreshold>
+          <FanSpeed>96</FanSpeed>
+        </TemperatureThreshold>
+      
+      </TemperatureThresholds>
+      
+      <FanSpeedPercentageOverrides>
+        <FanSpeedPercentageOverride>
+          <FanSpeedPercentage>0</FanSpeedPercentage>
+          <FanSpeedValue>255</FanSpeedValue>
+          <TargetOperation>ReadWrite</TargetOperation>
+        </FanSpeedPercentageOverride>
+      </FanSpeedPercentageOverrides>
+    </FanConfiguration>
+  </FanConfigurations>
+  
+  <RegisterWriteConfigurations>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>34</Register>
+      <Value>1</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>1</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Select thermal zone</Description>
+    </RegisterWriteConfiguration>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>38</Register>
+      <Value>28</Value>
+      <ResetRequired>true</ResetRequired>
+      <ResetValue>0</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Fake thermal zone temperature</Description>
+    </RegisterWriteConfiguration>
+  </RegisterWriteConfigurations>
+  
+</FanControlConfigV2>


### PR DESCRIPTION
Added config for my HP Elitebook 850 G5.

This config was manually created based on "HP EliteBook*.xml" configs (HP EliteBook 8760w.xml, HP EliteBook 840 G2.xml, etc.) and some others. MaxSpeedValue/MinSpeedValue were detected/checked  with ec-probe tool. The config was created for HP EliteBook 850 G5 with Intel i5-8250U CPU and BIOS Q78 Ver. 01.16.00. And it was tested only on Linux. It may be necessary to change/adjust temperature threshoulds for different CPU or/and personal preferences but it works nice for me.

I had no a big problem with cooler on this laptop until I upgraded BIOS to version 1.15.00 and it turned out that I could not rollback to my old version 1.00.5. I wanted to rollback to old BIOS because with a new version this laptop became too hot on high loads (cpu cooler didn't want to speed up enough).

I tried to find a compromise between silence and heating and I hope I made it good enough. 