### PR TITLE
Fan.cs - Feature/update EC when needed (ramping up cycle); Config: Thinkpad E570

### DIFF
--- a/Configs/Lenovo ThinkPad E570.xml
+++ b/Configs/Lenovo ThinkPad E570.xml
@@ -39,8 +39,8 @@
           <FanSpeed>8</FanSpeed>
         </TemperatureThreshold>
 		<TemperatureThreshold>
-		  <UpThreshold>90</UpThreshold>
-		  <DownThreshold>80</DownThreshold>
+		  <UpThreshold>74</UpThreshold>
+		  <DownThreshold>73</DownThreshold>
 		  <FanSpeed>100</FanSpeed>
 		</TemperatureThreshold>
       </TemperatureThresholds>

--- a/Configs/Lenovo ThinkPad E570.xml
+++ b/Configs/Lenovo ThinkPad E570.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>Lenovo Thinkpad E570</NotebookModel>
+  <Author>matkovic</Author>
+  <EcPollInterval>1000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>75</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>133</ReadRegister>
+      <WriteRegister>47</WriteRegister>
+      <MinSpeedValue>0</MinSpeedValue>
+      <MaxSpeedValue>64</MaxSpeedValue>
+      <IndependentReadMinMaxValues>true</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>72</MaxSpeedValueRead>
+      <ResetRequired>true</ResetRequired>
+      <FanSpeedResetValue>128</FanSpeedResetValue>
+      <FanDisplayName>System Fan</FanDisplayName>
+      <TemperatureThresholds>
+		<TemperatureThreshold>
+      	  <FanSpeed>0</FanSpeed>
+		  <UpThreshold>0</UpThreshold>
+		  <DownThreshold>0</DownThreshold>
+		</TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>50</UpThreshold>
+          <DownThreshold>30</DownThreshold>
+          <FanSpeed>4</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>60</UpThreshold>
+          <DownThreshold>50</DownThreshold>
+          <FanSpeed>6</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>60</DownThreshold>
+          <FanSpeed>8</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>

--- a/Configs/Lenovo ThinkPad E570.xml
+++ b/Configs/Lenovo ThinkPad E570.xml
@@ -38,6 +38,11 @@
           <DownThreshold>60</DownThreshold>
           <FanSpeed>8</FanSpeed>
         </TemperatureThreshold>
+		<TemperatureThreshold>
+		  <UpThreshold>90</UpThreshold>
+		  <DownThreshold>80</DownThreshold>
+		  <FanSpeed>100</FanSpeed>
+		</TemperatureThreshold>
       </TemperatureThresholds>
       <FanSpeedPercentageOverrides />
     </FanConfiguration>

--- a/Core/StagWare.FanControl/Fan.cs
+++ b/Core/StagWare.FanControl/Fan.cs
@@ -32,6 +32,7 @@ namespace StagWare.FanControl
         private readonly Dictionary<int, FanSpeedPercentageOverride> overriddenValues;
 
         private float targetFanSpeed;
+        private float previousTargetFanSpeed = 0;
 
         #endregion
 
@@ -135,7 +136,9 @@ namespace StagWare.FanControl
 
             if (!readOnly)
             {
-                ECWriteValue(PercentageToFanSpeed(speed));
+                if(previousTargetFanSpeed != speed)
+                    ECWriteValue(PercentageToFanSpeed(speed));
+                previousTargetFanSpeed = speed;
             }
         }
 


### PR DESCRIPTION
I added config for Lenovo ThinkPad E570, where 100% of the target fan speed is really some "special" full fan speed (also really loud). This is only enabled for critical temperature. Without this, this fan has only 5 speed modes (0x01, 0x02, 0x03, 0x04, 0x05) written to 0x2F EC. The special fast+loud one is 0x40.

Another thing that I noticed is the constant ramping up cycle on my laptop - everytime when the EcPollInterval started with checking up the temperature and setting the value in EC, fan stops for a moment and starts again with the desired fan speed. The problem is with the constant writing to EC, which somehow resets or reinitializes fan. I think the same behavior is described in #925.

I added a few lines to the Fan.cs, so that writing to EC happens only when needed (when the change in target speed actually happens). This stops constant fan ramping up after EcPollInterval, but still when the change in target speed happens, it resets the fan for a moment. Maybe its not the best solution, but it better than torturing the fan with constant on-ing and off-ing.