### PR TITLE
Added Dockerfile to install wget for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM mono:6.12
+
+RUN apt update && apt install --no-install-recommends -y wget
+
+WORKDIR /nbfc
+
+CMD ./build.sh


### PR DESCRIPTION
https://github.com/hirschmann/nbfc/wiki/How-to-build-NBFC#build-on-linux-via-docker

The instructions here for Docker do not work, because of missing `wget` in the `mono` image. I've added a Dockerfile so people can build this image and directly run it to create the build, something like the following:

    docker build -t nbfc-build . && docker run -it --rm -v "$(pwd):/nbfc" nbfc-build

We can update the wiki to reflect this once this PR is merged.