### PR TITLE
Add Lenovo ThinkPad L13 Config

### DIFF
--- a/Configs/Lenovo Thinkpad L13.xml
+++ b/Configs/Lenovo Thinkpad L13.xml
@@ -46,11 +46,6 @@
         <TemperatureThreshold>
           <UpThreshold>90</UpThreshold>
           <DownThreshold>85</DownThreshold>
-          <FanSpeed>48</FanSpeed>
-        </TemperatureThreshold>
-        <TemperatureThreshold>
-          <UpThreshold>100</UpThreshold>
-          <DownThreshold>95</DownThreshold>
           <FanSpeed>100</FanSpeed>
         </TemperatureThreshold>
       </TemperatureThresholds>

--- a/Configs/Lenovo Thinkpad L13.xml
+++ b/Configs/Lenovo Thinkpad L13.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>LENOVO 20R4001CBR</NotebookModel>
+  <Author>Rafaelti</Author>
+  <EcPollInterval>2000</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>92</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>149</ReadRegister>
+      <WriteRegister>148</WriteRegister>
+      <MinSpeedValue>255</MinSpeedValue>
+      <MaxSpeedValue>0</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>0</MaxSpeedValueRead>
+      <ResetRequired>false</ResetRequired>
+      <FanSpeedResetValue>100</FanSpeedResetValue>
+      <FanDisplayName>Fan</FanDisplayName>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>65</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>0</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>70</UpThreshold>
+          <DownThreshold>65</DownThreshold>
+          <FanSpeed>8.235294</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>75</UpThreshold>
+          <DownThreshold>70</DownThreshold>
+          <FanSpeed>16.0784321</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>80</UpThreshold>
+          <DownThreshold>75</DownThreshold>
+          <FanSpeed>24.705883</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>85</UpThreshold>
+          <DownThreshold>80</DownThreshold>
+          <FanSpeed>32</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>90</UpThreshold>
+          <DownThreshold>85</DownThreshold>
+          <FanSpeed>48</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations>
+    <RegisterWriteConfiguration>
+      <WriteMode>Set</WriteMode>
+      <WriteOccasion>OnInitialization</WriteOccasion>
+      <Register>147</Register>
+      <Value>20</Value>
+      <ResetRequired>false</ResetRequired>
+      <ResetValue>4</ResetValue>
+      <ResetWriteMode>Set</ResetWriteMode>
+      <Description>Set EC to manual control</Description>
+    </RegisterWriteConfiguration>
+  </RegisterWriteConfigurations>
+</FanControlConfigV2>

--- a/Configs/Lenovo Thinkpad L13.xml
+++ b/Configs/Lenovo Thinkpad L13.xml
@@ -48,6 +48,11 @@
           <DownThreshold>85</DownThreshold>
           <FanSpeed>48</FanSpeed>
         </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>100</UpThreshold>
+          <DownThreshold>95</DownThreshold>
+          <FanSpeed>100</FanSpeed>
+        </TemperatureThreshold>
       </TemperatureThresholds>
       <FanSpeedPercentageOverrides />
     </FanConfiguration>


### PR DESCRIPTION
Adds a new config for Lenovo ThinkPad L13.

Tested on a Lenovo Thinkpad L13 Gen 2 i7-1165G7

Credits to: https://www.reddit.com/r/thinkpad/comments/ldj5w5/comment/hvi2bx7/